### PR TITLE
Update RenameJPGs.py

### DIFF
--- a/RenameJPGs.py
+++ b/RenameJPGs.py
@@ -16,6 +16,7 @@ while keepGoing:
     root = Tk()
     root.update()
     filenameList = filedialog.askopenfilename(multiple=True)
+    print(len(filenameList))
     root.destroy()
 
     for filename in filenameList:
@@ -23,21 +24,32 @@ while keepGoing:
         exifData = im._getexif()
 
         try:
-            for tag, value in exifData.items():
-                if tag == 0x0132:
-                    path = getPath(filename)
-                    year = value[0:4]
-                    month = value[5:7]
-                    day = value[8:10]
-                    hours = value[11:13]
-                    minutes = value[14:16]
-                    seconds = value[17:19]
-                    newFilename = path + year + month + day + hours + minutes + seconds + ".jpg"
-                    os.rename(filename, newFilename)
-                    break
+            # Tag 0x9003 is for the DateTime when the image was originally created
+            value = exifData.get(0x9003)
+            if value != 'None' and value != '':
+                path = getPath(filename)
+                year = value[0:4]
+                month = value[5:7]
+                day = value[8:10]
+                hours = value[11:13]
+                minutes = value[14:16]
+                seconds = value[17:19]
+                newFilename = path + year + month + day + hours + minutes + seconds + ".jpg"
+                os.rename(filename, newFilename)
+            # Tag 0x0132 is for the DateTime when the image was last modified
+            else:
+                value = exifData.get(0x0132)
+                path = getPath(filename)
+                year = value[0:4]
+                month = value[5:7]
+                day = value[8:10]
+                hours = value[11:13]
+                minutes = value[14:16]
+                seconds = value[17:19]
+                newFilename = path + year + month + day + hours + minutes + seconds + ".jpg"
+                os.rename(filename, newFilename)
 
         except:
-            messagebox.showerror(message='Error occured; possibly because no EXIF data exists.',title='Error')
+            messagebox.showerror(message='Error occurred; possibly because no EXIF data exists.',title='Error')
 
     keepGoing = messagebox.askyesno(message='Select more jpg files to rename?',icon='question',title='More JPEGs?')
-


### PR DESCRIPTION
This commit reflects the following edits:
(1) Checking tag 0x9003 (DateTime when JPG file was originally created). Only if this fails does it then check tag 0x0132 (DateTime when JPG file was last modified). If that fails, then an error message is issued.
(2) The break statements have been removed from the try block. These were causing the code to exit the for loop prematurely -- i.e., when the user selected multiple JPG files for renaming, only the first selected JPG file was being renamed.
(3) Spelling of "occurred" in the error message was corrected.